### PR TITLE
Prevents silent crash in PHP8

### DIFF
--- a/ConvertDb.php
+++ b/ConvertDb.php
@@ -733,7 +733,11 @@ class ConvertDb
 
     protected function doQuery($sql)
     {
-        $ret = mysqli_query($this->link, $sql);
+        try { 
+            $ret = mysqli_query($this->link, $sql);
+        } catch (Exception $e) {
+            $ret = false;
+        } 
         if ($ret === false) {
             $this->errorMsg = '<code>' . $sql . '</code><br>' . mysqli_errno($this->link) . ': ' . mysqli_error($this->link) . '<br>';
         } else {


### PR DESCRIPTION
Test: switch to PHP 8.1, import this .sql file to your database.

Run without fix: silent death
Run with fix: nice error message which would be shown in PHP 7.4 with a problem summary. 

[test.zip](https://github.com/lat9/database-converter/files/12228802/test.zip)
